### PR TITLE
Handle linebreaks correctly for unicode em-dash

### DIFF
--- a/deepLuna.py
+++ b/deepLuna.py
@@ -204,14 +204,28 @@ def remove_ruby_text(line):
     return ret
 
 
+def unicode_aware_len(string):
+    # Certain unicode codepoints render as double-width - account for that here
+    # when calculating the length of a string
+    DOUBLEWIDE_CHARS = set([u"―"])
+    length = 0
+    for c in string:
+        if c in DOUBLEWIDE_CHARS:
+            length += 2
+        else:
+            length += 1
+
+    return length
+
+
 def noruby_len(line):
     # Get the length of a line as if it did not contain any ruby text
     try:
-        return len(remove_ruby_text(line))
+        return unicode_aware_len(remove_ruby_text(line))
     except AssertionError as e:
         # There are non-conformant lines in the current script. Fail gracefully
         print(e)
-        return len(line)
+        return unicode_aware_len(line)
 
 
 def ruby_aware_split_words(line):


### PR DESCRIPTION
Unicode em-dash renders as a doublewide character, which throws off a naïve `len` based line break in some cases:

![2021-10-18-231631_1818x340_scrot](https://user-images.githubusercontent.com/2476799/137838050-48ce156a-15e1-45dc-8626-ba618a40572f.png)

There are only three dash characters, but they render as 6 slots (compare to chars on line above).
This PR adds a new length checking method that accounts for the rendering differences

![2021-10-18-231307_1724x334_scrot](https://user-images.githubusercontent.com/2476799/137837882-9e42d8ee-cd50-4817-9281-4acb1683b733.png)
