### PR TITLE
Fix cursor accounting for _long_ split lines

### DIFF
--- a/deepLuna.py
+++ b/deepLuna.py
@@ -927,9 +927,25 @@ def insert_translation(scriptFile, translation_table_filename, scriptFileTransla
             broken_line = add_linebreaks(
                 charswapped_line, 55, start_cursor_pos=cursor_position)
 
+            # print(
+            #     f"{offset}: Start cursor pos {cursor_position}, "
+            #     f"broken line: {broken_line}")
+
             # Update cursor position with the length of the final line
-            cursor_position += len(broken_line.split('\n')[-1])
-            cursor_position = cursor_position % 55
+            # If the broken line is only a single line, increment cursor pos
+            # If it is _multiple_ lines, then we only count the len of the
+            # final line
+            did_break_line = len(broken_line.split('\n')) > 1
+            final_broken_line = broken_line.split('\n')[-1]
+            if did_break_line:
+                cursor_position = noruby_len(final_broken_line)
+            else:
+                cursor_position += noruby_len(final_broken_line)
+                cursor_position = cursor_position % 55
+
+            # print(
+            #     f"{offset}: Last line: {final_broken_line} "
+            #     f"New cursor position: {cursor_position}")
 
             # Encode and add trailing \r\n\
             line_to_inject = broken_line.encode("utf-8") + b'\x0D\x0A'


### PR DESCRIPTION
Previously, when breaking lines, we would take the length of the final section of the broken line and add that to the cursor position, e.g.

```
ZM("20 characters of text");
// Cursor position: 20
MSAD("20 characters of text")
// Cursor position: 40
MSAD("5 characters of text")
// Cursor position: 45
-> "20 characters of text20characters of text5 characters of text"
```
however, this is wrong for lines where a MSAD causes a line break - 

```
ZM("20 characters of text");
// Cursor position: 20
MSAD("40 characters of text")
// Gets wrapped to 35 chars + 5 chars
// Cursor position: 20 + 5 (WRONG!)
```

